### PR TITLE
auto use browserify transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ var contents = read.sync(path.join(__dirname, 'files'))
 ### Browserify example:
 
 ```bash
-browserify index.js -t read-directory/transform -o bundle.js 
+browserify index.js -t read-directory -o bundle.js
 ```
 
 ### budo example:
 
 ```bash
-budo index.js:bundle.js -- -t read-directory/transform
+budo index.js:bundle.js -- -t read-directory
 ```
 
 ## API

--- a/index.js
+++ b/index.js
@@ -31,6 +31,12 @@ var defaultOptions = {
 * })
 **/
 module.exports = module.exports.async = function readDirectory (dir, options, callback) {
+  // browserify transform
+  if (typeof dir === 'string' && !/\n/.test(dir) && options && options._flags) {
+    var args = Array.prototype.slice.apply(arguments)
+    return require('./transform.js').apply(this, args)
+  }
+
   if (typeof options === 'function') {
     callback = options
     options = {}


### PR DESCRIPTION
Should make using this as a transform a bit easier. Changes from:
```sh
$ browserify -t read-directory/transform
```

to
```sh
$ browserify -t read-directory
```

Patch change, because the former will still work as expected. Hope this good. Thanks! :grin: