### PR TITLE
Watch files

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,13 +43,13 @@ var contents = read.sync(path.join(__dirname, 'files'))
 ### Browserify example:
 
 ```bash
-browserify index.js -t read-directory/transform -o bundle.js 
+browserify index.js -t read-directory -o bundle.js
 ```
 
 ### budo example:
 
 ```bash
-budo index.js:bundle.js -- -t read-directory/transform
+budo index.js:bundle.js -- -t read-directory
 ```
 
 ## API

--- a/README.md
+++ b/README.md
@@ -65,7 +65,6 @@ Read the contents of a directory asynchronously
 -   `dir` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** – The directory to read
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `options.fs` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** – alternate fs implementation, optional
-    -   `options.extensions` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** – include or exclude file extensions in keys of returned object
     -   `options.dirnames` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** – include or exclude subdirectory names in keys of returned object
     -   `options.encoding` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** – encoding of files, default: utf8
     -   `options.filter` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** – glob pattern for filtering files, examples: `*.md`, `*.css`
@@ -91,7 +90,6 @@ Read the contents of a directory asynchronously
 -   `dir` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** – The directory to read
 -   `options` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** 
     -   `options.fs` **[Object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object)** – alternate fs implementation, optional
-    -   `options.extensions` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** – include or exclude file extensions in keys of returned object
     -   `options.dirnames` **[Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean)** – include or exclude subdirectory names in keys of returned object
     -   `options.encoding` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** – encoding of files, default: utf8
     -   `options.filter` **[String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String)** – glob pattern for filtering files, examples: `*.md`, `*.css`

--- a/index.js
+++ b/index.js
@@ -31,6 +31,12 @@ var defaultOptions = {
 * })
 **/
 module.exports = module.exports.async = function readDirectory (dir, options, callback) {
+  // browserify transform
+  if (typeof dir === 'string' && !/\n/.test(dir) && options && options._flags) {
+    var args = Array.prototype.slice.apply(arguments)
+    return require('./transform.js').apply(this, args)
+  }
+
   if (typeof options === 'function') {
     callback = options
     options = {}

--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ var defaults = require('defaults')
 var defaultOptions = {
   encoding: 'utf8',
   filter: '**/*',
-  extensions: false,
   dirnames: false
 }
 
@@ -17,7 +16,6 @@ var defaultOptions = {
 * @param {String} dir – The directory to read
 * @param {Object} options
 * @param {Object} options.fs – alternate fs implementation, optional
-* @param {Boolean} options.extensions – include or exclude file extensions in keys of returned object
 * @param {Boolean} options.dirnames – include or exclude subdirectory names in keys of returned object
 * @param {String} options.encoding – encoding of files, default: utf8
 * @param {String} options.filter – glob pattern for filtering files, examples: `*.md`, `*.css`
@@ -46,7 +44,6 @@ module.exports = module.exports.async = function readDirectory (dir, options, ca
 
   var xfs = options.fs || fs
   var transform = options.transform
-  var extensions = options.extensions
   var dirnames = options.dirnames
   var encoding = options.encoding
   var filter = options.filter
@@ -77,7 +74,6 @@ module.exports = module.exports.async = function readDirectory (dir, options, ca
         if (err) return done(err)
         var parsed = path.parse(filepath)
         if (transform) file = transform(file, parsed)
-        if (!extensions) filepath = parsed.name
         if (dirnames) filepath = parsed.dir.length ? parsed.dir + '/' + filepath : filepath
         contents[filepath] = file
         done()
@@ -92,7 +88,6 @@ module.exports = module.exports.async = function readDirectory (dir, options, ca
 * @param {String} dir – The directory to read
 * @param {Object} options
 * @param {Object} options.fs – alternate fs implementation, optional
-* @param {Boolean} options.extensions – include or exclude file extensions in keys of returned object
 * @param {Boolean} options.dirnames – include or exclude subdirectory names in keys of returned object
 * @param {String} options.encoding – encoding of files, default: utf8
 * @param {String} options.filter – glob pattern for filtering files, examples: `*.md`, `*.css`
@@ -108,7 +103,6 @@ module.exports.sync = function readDirectorySync (dir, options) {
 
   var xfs = options.fs || fs
   var transform = options.transform
-  var extensions = options.extensions
   var dirnames = options.dirnames
   var encoding = options.encoding
   var filter = options.filter
@@ -125,7 +119,6 @@ module.exports.sync = function readDirectorySync (dir, options) {
     if (stats.isFile()) {
       var file = xfs.readFileSync(fullpath, encoding)
       if (transform) file = transform(file, parsed)
-      if (!extensions) filepath = parsed.name
       if (dirnames) filepath = parsed.dir.length ? parsed.dir + '/' + filepath : filepath
       contents[filepath] = file
     }


### PR DESCRIPTION
Builds on top of #2 — this allows files to be picked up by `watchify`, which will cause a reload to happen if an included file changes. This is ideal for example when editing a directory of docs!

Unfortunately the only way to make it happen was to remove the `extensions` option — because the names in the object need to match the filenames on disc I couldn't think of a better way to do this. Luckily this should be fairly easy to fix for people in Userland (e.g. `name.split('.')[0]`). So definitely a semver major.

Hope this patch is good; keen to hear your thoughts! Thanks! :sparkles:

## Reference
- [brfs use of static-module + emit('file')](https://github.com/browserify/brfs/blob/master/index.js)