### PR TITLE
Bump static module dependency to fix security problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "defaults": "^1.0.3",
     "each-async": "^1.1.1",
     "glob": "^7.1.2",
-    "static-module": "^1.3.2",
+    "static-module": "^3.0.0",
     "through2": "^2.0.3"
   }
 }


### PR DESCRIPTION
Fixes:

Moderate        Sandbox Breakout / Arbitrary Code Execution                   
                                                                                
  Package         static-eval                                                   
                                                                                
  Patched in      >=2.0.0                                                       
                                                                                
  Dependency of  .....                                                 
                                                                                
  Path            .... > read-directory > static-module > static-eval  
                                                                                
  More info       https://nodesecurity.io/advisories/548   