### PR TITLE
Fixes dirnames option

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,6 @@ module.exports = module.exports.async = function readDirectory (dir, options, ca
         if (err) return done(err)
         var parsed = path.parse(filepath)
         if (transform) file = transform(file, parsed)
-        if (transform) file = transform(file, parsed)
         filepath = parsed.name + parsed.ext
         if (dirnames) filepath = parsed.dir.length ? path.join(parsed.dir, filepath) : filepath
         contents[filepath] = file

--- a/index.js
+++ b/index.js
@@ -74,7 +74,9 @@ module.exports = module.exports.async = function readDirectory (dir, options, ca
         if (err) return done(err)
         var parsed = path.parse(filepath)
         if (transform) file = transform(file, parsed)
-        if (dirnames) filepath = parsed.dir.length ? parsed.dir + '/' + filepath : filepath
+        if (transform) file = transform(file, parsed)
+        filepath = parsed.name + parsed.ext
+        if (dirnames) filepath = parsed.dir.length ? path.join(parsed.dir, filepath) : filepath
         contents[filepath] = file
         done()
       })
@@ -119,7 +121,8 @@ module.exports.sync = function readDirectorySync (dir, options) {
     if (stats.isFile()) {
       var file = xfs.readFileSync(fullpath, encoding)
       if (transform) file = transform(file, parsed)
-      if (dirnames) filepath = parsed.dir.length ? parsed.dir + '/' + filepath : filepath
+      filepath = parsed.name + parsed.ext
+      if (dirnames) filepath = parsed.dir.length ? path.join(parsed.dir, filepath) : filepath
       contents[filepath] = file
     }
   })

--- a/tests/index.js
+++ b/tests/index.js
@@ -40,7 +40,7 @@ test('sync: filter out .txt', function (t) {
 })
 
 test('async: include extensions', function (t) {
-  read(path.join(__dirname, 'files'), { extensions: true }, function (err, contents) {
+  read(path.join(__dirname, 'files'), function (err, contents) {
     t.notOk(err)
     t.ok(contents)
     t.equal(typeof contents, 'object')
@@ -54,7 +54,7 @@ test('async: include extensions', function (t) {
 })
 
 test('sync: include extensions', function (t) {
-  var contents = read.sync(path.join(__dirname, 'files'), { extensions: true })
+  var contents = read.sync(path.join(__dirname, 'files'))
   t.ok(contents)
   t.equal(typeof contents, 'object')
   var keys = Object.keys(contents)
@@ -65,26 +65,58 @@ test('sync: include extensions', function (t) {
   t.end()
 })
 
-test('async: exclude extensions', function (t) {
-  read(path.join(__dirname, 'files'), { extensions: true }, function (err, contents) {
+test('async: include dirnames', function (t) {
+  read(path.join(__dirname, 'files'), { dirnames: true }, function (err, contents) {
     t.notOk(err)
     t.ok(contents)
     t.equal(typeof contents, 'object')
     var keys = Object.keys(contents)
     t.equal(keys.length, 7)
+    var foundDirs = false
+    keys.forEach(function (key) {
+      if (key.split(path.sep).length > 1) foundDirs = true
+    })
+    t.ok(foundDirs)
     t.end()
   })
 })
 
-test('sync: exclude extensions', function (t) {
-  var contents = read.sync(path.join(__dirname, 'files'), { extensions: true })
+test('sync: include dirnames', function (t) {
+  var contents = read.sync(path.join(__dirname, 'files'), { dirnames: true })
   t.ok(contents)
   t.equal(typeof contents, 'object')
   var keys = Object.keys(contents)
-  t.equal(keys.length, 7)
+  var foundDirs = false
   keys.forEach(function (key) {
-    t.equal(key.split('.').length, 2)
+    if (key.split(path.sep).length > 1) foundDirs = true
   })
+  t.ok(foundDirs)
+  t.end()
+})
+
+test('async: exclude dirnames', function (t) {
+  read(path.join(__dirname, 'files'), { dirnames: false }, function (err, contents) {
+    t.notOk(err)
+    t.ok(contents)
+    t.equal(typeof contents, 'object')
+    var keys = Object.keys(contents)
+    keys.forEach(function (key) {
+      t.equal(key.split(path.sep).length, 1)
+    })
+    t.equal(keys.length, 7)
+    t.end()
+  })
+})
+
+test('sync: exclude dirnames', function (t) {
+  var contents = read.sync(path.join(__dirname, 'files'), { dirnames: false })
+  t.ok(contents)
+  t.equal(typeof contents, 'object')
+  var keys = Object.keys(contents)
+  keys.forEach(function (key) {
+    t.equal(key.split(path.sep).length, 1)
+  })
+  t.equal(keys.length, 7)
   t.end()
 })
 


### PR DESCRIPTION
Version 3.0.1 of `read-directory` removed support for the extensions option, and broke the output of dirnames in the process.

To reproduce:
```
$ mkdir -p foo1/foo2/foo3/foo4
$ echo 'Hi' > foo1/foo2/foo3/foo4/file.md
```

`read-directory` 2.1.1:
```js
console.log(readDirectory.sync('./foo1', {dirnames: true}))
// { 'foo2/foo3/foo4/file': 'Hi\n' }
console.log(readDirectory.sync('./foo1', {dirnames: false}))
// { file: 'Hi\n' }
```

`read-directory` 3.0.1:
```js
console.log(readDirectory.sync('./foo1', {dirnames: true}))
// { 'foo2/foo3/foo4/foo2/foo3/foo4/file.md': 'Hi\n' }
console.log(readDirectory.sync('./foo1', {dirnames: false}))
// { 'foo2/foo3/foo4/file.md': 'Hi\n' }
```

The addition of the `.md` extension is expected, but the rest of the filepath is wrong.

This is a fairly large issue for Mozilla's Taskcluster https://github.com/taskcluster/taskcluster/pull/1001
(See https://github.com/s3ththompson/md-directory/issues/2 for context)